### PR TITLE
Update amphp/http dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-filter": "*",
         "amphp/amp": "^3",
         "amphp/dns": "^2",
-        "amphp/http": "^1.5",
+        "amphp/http": "^2-dev",
         "amphp/http-client": "^5",
         "amphp/sync": "^2",
         "psr/http-message": "^1"


### PR DESCRIPTION
The next version of the beta of http-client and [http-server](https://github.com/amphp/http-server/blob/d579d5bd521ab74989e61259b3ded48b48baf094/composer.json#L37) both use the new version of amphp/http. This package needs an update too to stay compatible.

I run tests locally and they are all passing. 👍 